### PR TITLE
Resize images for display in frames

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -44,6 +44,7 @@
     "react-player": "^2.16.0",
     "react-timeago": "^7.2.0",
     "shadcn-ui": "^0.8.0",
+    "sharp": "0.32.6",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
     "truncate-eth-address": "^1.0.2",

--- a/website/src/app/api/resizeImage/route.ts
+++ b/website/src/app/api/resizeImage/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import sharp from "sharp";
+
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams;
+  const url = searchParams.get("imageUrl");
+  if (url == null) {
+    return Response.json({ error: "Failed to parse url" }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(url);
+    const buffer = await response.arrayBuffer();
+    const image = sharp(buffer);
+    const metadata = await image.metadata();
+
+    // TODO adjust this
+    const maxWidth = 1000;
+    const maxHeight = 1000;
+    if (metadata.width == null || metadata.height == null) {
+      return Response.json(
+        { error: "Failed to identify image width or height" },
+        { status: 500 }
+      );
+    }
+
+    const aspectRatio = metadata.width / metadata.height;
+
+    // Determine the target width and height
+    let targetWidth, targetHeight;
+    if (metadata.width / maxWidth > metadata.height / maxHeight) {
+      targetWidth = maxWidth;
+      targetHeight = Math.round(maxWidth / aspectRatio);
+    } else {
+      targetWidth = Math.round(maxHeight * aspectRatio);
+      targetHeight = maxHeight;
+    }
+
+    const resizedImageBuffer = await image
+      .resize({
+        // Frame image aspect ratio is 1.91:1 and 1170/612 is approximately 1.91:1.
+        // This width and height are double the width of frames on my mac so they should
+        // preserve image quality where possible.
+        // NOTE: I could be wrong on the quality part, I'm no expert on image resizing
+        width: 1170,
+        height: 612,
+        fit: "contain",
+        background: { r: 0, g: 0, b: 0, alpha: 1 }, // Black background
+      })
+      .toBuffer();
+
+    // Set the content type and return the image
+    return new NextResponse(resizedImageBuffer, {
+      headers: { "Content-Type": "image/jpeg" },
+    });
+  } catch (e) {
+    console.log(e);
+    return Response.json({ error: "Failed to resize" }, { status: 500 });
+  }
+}

--- a/website/src/app/app/inscribed-drops/mint/[chainIdString]/[tokenId]/layout.tsx
+++ b/website/src/app/app/inscribed-drops/mint/[chainIdString]/[tokenId]/layout.tsx
@@ -18,11 +18,12 @@ export async function generateMetadata({
 
   const image = sanitizeMediaUrl(inscribedDrop.metadata.image, true);
 
+  const imageUrl = `${WEBSITE_BASE_URL}/api/resizeImage?imageUrl=${image}`;
   return {
     other: {
       "fc:frame": "vNext",
-      "fc:frame:image": image,
-      "og:image": image,
+      "fc:frame:image": imageUrl,
+      "og:image": imageUrl,
       "fc:frame:button:1": "Mint",
       "fc:frame:button:1:action": "tx",
       "fc:frame:button:1:target": `${WEBSITE_BASE_URL}/api/frames/inscribed-drops/mint?chainId=${params.chainIdString}&tokenId=${params.tokenId}`,


### PR DESCRIPTION
This actually seemed to work properly when I tried it locally on this SVG (`http://localhost:3000/api/resizeImage?imageUrl=https://bafkreidrxeg52ha57kt6hbwghy4fbvc4gqtfkxhyvoql2hrfgm36m2ebb4.ipfs.nftstorage.link/`), so I think SVGs are supported as well but likely needs more testing